### PR TITLE
Scan PDF from URL

### DIFF
--- a/api/swagger.yaml
+++ b/api/swagger.yaml
@@ -44,7 +44,7 @@ paths:
         in: "formData"
         description: "Optional id number to associate with the file"
         required: false
-        type: "string"        
+        type: "string"
       responses:
         200:
           description: "A scan response"
@@ -52,6 +52,44 @@ paths:
             $ref: "#/definitions/inline_response_200"
         400:
           description: "Missing file"
+        422:
+          description: "Cannot process file: filetype, file error, or security problem."
+      x-swagger-router-controller: "File"
+  /url:
+    get:
+      tags:
+      - "url"
+      summary: "Submit a URL for checking"
+      description: ""
+      operationId: "scanUrl"
+      produces:
+      - "application/json"
+      parameters:
+      - name: "url"
+        in: "query"
+        description: "The url to scan"
+        required: true
+        type: "string"
+        pattern: "https?:\/\/.+"
+      - name: "maxPages"
+        in: "query"
+        description: "Override the default maximum number of pages to scan"
+        required: false
+        type: "integer"
+      - name: "id"
+        in: "query"
+        description: "Optional id number to associate with the file"
+        required: false
+        type: "string"
+      responses:
+        200:
+          description: "A scan response"
+          schema:
+            $ref: "#/definitions/inline_response_200"
+        400:
+          description: "Error processing URL"
+        404:
+          description: "File not found"
         422:
           description: "Cannot process file: filetype, file error, or security problem."
       x-swagger-router-controller: "File"
@@ -63,13 +101,13 @@ definitions:
         description: "the filename"
       id:
         type: "string"
-        description: "id number (if provided)"        
+        description: "id number (if provided)"
       hasText:
         type: "boolean"
         description: "does the file contain text"
       pages:
         type: "integer"
-        description: "number of pages in document"        
+        description: "number of pages in document"
 externalDocs:
   description: "Find out more about Swagger"
   url: "http://swagger.io"

--- a/controllers/File.js
+++ b/controllers/File.js
@@ -7,3 +7,7 @@ var File = require('./FileService');
 module.exports.scanFile = function scanFile (req, res, next) {
   File.scanFile(req.swagger.params, res, next);
 };
+
+module.exports.scanUrl = function scanUrl (req, res, next) {
+  File.scanUrl(req.swagger.params, res, next);
+};

--- a/controllers/FileService.js
+++ b/controllers/FileService.js
@@ -1,13 +1,33 @@
 'use strict';
+const url = require('url');
+const http = require('http');
+const https = require('https');
+const fs = require('fs');
 let	PDFParser = require("pdf2json"),
 	util = require('util'),
 	fileType = require('file-type');
-        
-        
+
+exports.scanUrl = function(args, res, next) {
+
+	getBufferFromUrl(args.url.value).then((pdfContent) => {
+
+		//console.log(util.inspect(pdfContent, {showHidden: false, depth: null}))
+		args.upfile = {
+			originalValue: {
+				originalname: "this.pdf"
+			},
+			value: {
+				buffer: pdfContent
+			}
+		};
+		this.scanFile(args, res, next);
+	}, (err) => {throw err}).catch((err) => console.log(err));
+}
+
 exports.scanFile = function(args, res, next) {
   /**
    * Submit a file for checking
-   * 
+   *
    *
    * upfile File The file to scan
    * returns inline_response_200
@@ -19,37 +39,37 @@ exports.scanFile = function(args, res, next) {
 };
 
 	//console.log(util.inspect(args.upfile, {showHidden: false, depth: null}))
-	
+
     let pdfParser = new PDFParser(this,1);
 
     pdfParser.on("pdfParser_dataError", errData => {
     	console.error(errData.parserError);
   		res.writeHead(422, {'statusMessage': "PDF Parsing error: " + errData.parserError},{'Content-Type': 'application/json'})
-  		res.end();  
+  		res.end();
     });
-    
+
     pdfParser.on("pdfParser_dataReady", pdfData => {
-    	
+
     	var filename = args.upfile.originalValue.originalname;
     	var hasText = false;
     	var pages = pdfData.formImage.Pages.length;
-    	
-    	// Check for text   	
+
+    	// Check for text
     	var pdftext = pdfParser.getRawTextContent();
     	pdftext = pdftext.replace(/\r\n----------------Page \(\d+\) Break----------------\r\n/g, '');
     	hasText = pdftext.length > 0 ? true : false;
-    	
+
     	//console.log(util.inspect(pdfData, {showHidden: false, depth: null}))
-        		
+
 		var output = {};
-		
+
 		output['application/json'] = {
 		  "filename" : filename,
 		  "hasText" : hasText,
 		  "pages": pages,
 		  "id":  args.id ? args.id.value : ""
 		};
-		
+
 		 res.setHeader('Content-Type', 'application/json');
 		 res.end(JSON.stringify(output || {}, null, 2));
 
@@ -60,7 +80,7 @@ exports.scanFile = function(args, res, next) {
 	if (mimetype != "application/pdf") {
 			console.log("Not a pdf");
 	  		res.writeHead(422,{'Content-Type': 'application/json'})
-  			res.end(JSON.stringify({'statusMessage': "Can't analyze this file type: " + mimetype}));  
+  			res.end(JSON.stringify({'statusMessage': "Can't analyze this file type: " + mimetype}));
   	} else {
   		// This should be a PDF, analyze it
 		pdfParser.parseBuffer(args.upfile.value.buffer);
@@ -68,3 +88,44 @@ exports.scanFile = function(args, res, next) {
 
 }
 
+/**
+ * Promisized HTTP GET call
+ */
+const getBufferFromUrl = function(reqUrl) {
+  // return new pending promise
+  return new Promise((resolve, reject) => {
+    // select http or https module, depending on reqested reqUrl
+    const lib = reqUrl.startsWith('https') ? https : http
+    const urlObj = url.parse(reqUrl);
+    const options = {
+      host: urlObj.host,
+      path: urlObj.path,
+      query: urlObj.query,
+    }
+    const request = lib.get(options, (response) => {
+      // handle http errors
+      if (response.statusCode < 200 || response.statusCode > 299) {
+         reject(new Error('Failed to load page, status code: ' + response.statusCode + ' - ' + reqUrl));
+      }
+			/*var file = fs.createWriteStream("file.pdf");
+			response.pipe(file);
+			response.on('end', () => {
+				fs.readFile("./file.pdf", function(err, linkString){
+					//console.log(err);
+					for (var key in linkString){
+						//console.log('bOBJ key: ', key);
+					}
+					resolve(linkString);
+				});
+			});*/
+      // temporary data holder
+      const body = [];
+      // on every content chunk, push it to the data array
+      response.on('data', (chunk) => body.push(chunk));
+      // we are done, resolve promise with those joined chunks
+      response.on('end', () => resolve(Buffer.concat(body)));
+    })
+    // handle connection errors of the request
+    request.on('error', (err) => reject(err))
+  })
+}

--- a/controllers/FileService.js
+++ b/controllers/FileService.js
@@ -2,26 +2,21 @@
 const url = require('url');
 const http = require('http');
 const https = require('https');
-const fs = require('fs');
-let	PDFParser = require("pdf2json"),
-	util = require('util'),
-	fileType = require('file-type');
+const PDFParser = require("pdf2json");
+const util = require('util');
+const fileType = require('file-type');
 
 exports.scanUrl = function(args, res, next) {
-
-	getBufferFromUrl(args.url.value).then((pdfContent) => {
-
-		//console.log(util.inspect(pdfContent, {showHidden: false, depth: null}))
-		args.upfile = {
-			originalValue: {
-				originalname: "this.pdf"
-			},
-			value: {
-				buffer: pdfContent
-			}
-		};
-		this.scanFile(args, res, next);
-	}, (err) => {throw err}).catch((err) => console.log(err));
+	const fileUrl = args.url.value;
+	const fileName = fileUrl.replace(/^.+\/([^\/\?]+)(\?.*)?$/, "$1");
+	const scanId = args.id ? args.id.value : "";
+	getBufferFromUrl(fileUrl)
+		.then((pdfBuffer) => testPDFBuffer(pdfBuffer), (err) => {throw err})
+		.then((results) => {
+			results.filename = fileName;
+			results.id = scanId;
+			sendAPIResponse(res, results);
+		}, (err) => {throw err}).catch((err) => sendAPIResponse(res, "", err));
 }
 
 exports.scanFile = function(args, res, next) {
@@ -32,64 +27,18 @@ exports.scanFile = function(args, res, next) {
    * upfile File The file to scan
    * returns inline_response_200
    **/
-  var examples = {};
-  examples['application/json'] = {
-  "filename" : "aeiou",
-  "hasText" : true
-};
-
-	//console.log(util.inspect(args.upfile, {showHidden: false, depth: null}))
-
-    let pdfParser = new PDFParser(this,1);
-
-    pdfParser.on("pdfParser_dataError", errData => {
-    	console.error(errData.parserError);
-  		res.writeHead(422, {'statusMessage': "PDF Parsing error: " + errData.parserError},{'Content-Type': 'application/json'})
-  		res.end();
-    });
-
-    pdfParser.on("pdfParser_dataReady", pdfData => {
-
-    	var filename = args.upfile.originalValue.originalname;
-    	var hasText = false;
-    	var pages = pdfData.formImage.Pages.length;
-
-    	// Check for text
-    	var pdftext = pdfParser.getRawTextContent();
-    	pdftext = pdftext.replace(/\r\n----------------Page \(\d+\) Break----------------\r\n/g, '');
-    	hasText = pdftext.length > 0 ? true : false;
-
-    	//console.log(util.inspect(pdfData, {showHidden: false, depth: null}))
-
-		var output = {};
-
-		output['application/json'] = {
-		  "filename" : filename,
-		  "hasText" : hasText,
-		  "pages": pages,
-		  "id":  args.id ? args.id.value : ""
-		};
-
-		 res.setHeader('Content-Type', 'application/json');
-		 res.end(JSON.stringify(output || {}, null, 2));
-
-    });
-
-	// Check to make sure this is a PDF file (by MIME type)
-	var mimetype = fileType(args.upfile.value.buffer).mime;
-	if (mimetype != "application/pdf") {
-			console.log("Not a pdf");
-	  		res.writeHead(422,{'Content-Type': 'application/json'})
-  			res.end(JSON.stringify({'statusMessage': "Can't analyze this file type: " + mimetype}));
-  	} else {
-  		// This should be a PDF, analyze it
-		pdfParser.parseBuffer(args.upfile.value.buffer);
-	}
-
+ 	const fileName = args.upfile.originalValue.originalname;
+ 	const scanId = args.id ? args.id.value : "";
+	let pdfBuffer = args.upfile.value.buffer;
+ 	testPDFBuffer(pdfBuffer).then((results) => {
+ 			results.filename = fileName;
+ 			results.id = scanId;
+ 			sendAPIResponse(res, results);
+ 		}, (err) => {throw err}).catch((err) => sendAPIResponse(res, "", err));
 }
 
 /**
- * Promisized HTTP GET call
+ * Promisized HTTP GET call that returns a Buffer
  */
 const getBufferFromUrl = function(reqUrl) {
   // return new pending promise
@@ -107,17 +56,6 @@ const getBufferFromUrl = function(reqUrl) {
       if (response.statusCode < 200 || response.statusCode > 299) {
          reject(new Error('Failed to load page, status code: ' + response.statusCode + ' - ' + reqUrl));
       }
-			/*var file = fs.createWriteStream("file.pdf");
-			response.pipe(file);
-			response.on('end', () => {
-				fs.readFile("./file.pdf", function(err, linkString){
-					//console.log(err);
-					for (var key in linkString){
-						//console.log('bOBJ key: ', key);
-					}
-					resolve(linkString);
-				});
-			});*/
       // temporary data holder
       const body = [];
       // on every content chunk, push it to the data array
@@ -128,4 +66,72 @@ const getBufferFromUrl = function(reqUrl) {
     // handle connection errors of the request
     request.on('error', (err) => reject(err))
   })
+}
+
+/**
+ * Run PDF tests on a given file Buffer
+ */
+const testPDFBuffer = function(fileBuffer) {
+	return new Promise((resolve, reject) => {
+		let pdfParser = new PDFParser(this,1);
+
+		pdfParser.on("pdfParser_dataError", errData => {
+			let dataErr = new Error("PDF Parsing error: " + errData.parserError);
+			dataErr.code = 422;
+			reject(dataErr);
+		});
+
+		pdfParser.on("pdfParser_dataReady", pdfData => {
+			var hasText = false;
+			var pages = pdfData.formImage.Pages.length;
+
+			// Check for text
+			var pdftext = pdfParser.getRawTextContent();
+			pdftext = pdftext.replace(/\r\n----------------Page \(\d+\) Break----------------\r\n/g, '');
+			hasText = pdftext.length > 0 ? true : false;
+
+			//console.log(util.inspect(pdfData, {showHidden: false, depth: null}))
+			resolve({
+				hasText: hasText,
+				pages: pages
+			});
+		});
+
+		// Check to make sure this is a PDF file (by MIME type)
+		var mimetype = fileType(fileBuffer).mime;
+		if (mimetype != "application/pdf") {
+			let notPDF = new Error("Can't analyze this file type: " + mimetype);
+			notPDF.code = 422;
+			reject(notPDF);
+		} else {
+			// This should be a PDF, analyze it
+			pdfParser.parseBuffer(fileBuffer);
+		}
+	});
+}
+
+/*
+ * generic API response wrapper
+ */
+const sendAPIResponse = function(res, data, err) {
+  let contentType = "application/json";
+	let wrappedData = {
+		'application/json': data
+	};
+  let responseData = JSON.stringify(wrappedData);
+  res.statusCode = 200;
+
+  if (err){
+		//send error to the console
+		console.error(err);
+    res.statusCode = (err.code||'400');
+    contentType = "application/json";
+    let errMsg = {statusMessage: err.message};
+    if (data.length){ //in case there is data to pass along
+      errMsg.data = data;
+    }
+    responseData = JSON.stringify(errMsg);
+  }
+  res.setHeader('Content-Type', contentType);
+  res.end(responseData);
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "prestart": "npm install",
-    "start": "node index.js"
+    "start": "node index.js",
+    "dev-server": "DEBUG=* ./node_modules/.bin/nodemon --debug --watch . --watch api/swagger.yaml index.js"
   },
   "keywords": [
     "swagger"
@@ -18,5 +19,8 @@
     "js-yaml": "^3.3.0",
     "pdf2json": "^1.1.7",
     "swagger-tools": "0.10.1"
+  },
+  "devDependencies": {
+    "nodemon": "^1.11.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prestart": "npm install",
     "start": "node index.js",
-    "dev-server": "DEBUG=* ./node_modules/.bin/nodemon --debug --watch . --watch api/swagger.yaml index.js"
+    "dev-server": "DEBUG=* ./node_modules/.bin/nodemon --debug=5859 --watch . --watch api/swagger.yaml index.js"
   },
   "keywords": [
     "swagger"


### PR DESCRIPTION
Added /url API endpoint that accepts a PDF url query parameter to scan.

Other changes are:
- Promisfied functions to better capture/throw errors.
- Better error handling and capturing
- Generic API response handler for 200 and error responses
- ```npm run dev-server``` script added to package to assist in development using nodemon