### PR TITLE
Increase buffer size for language detection

### DIFF
--- a/controllers/FileService.js
+++ b/controllers/FileService.js
@@ -76,7 +76,7 @@ const testPDFBuffer = function(fileBuffer, maxPages) {
 	return new Promise((resolve, reject) => {
 		//Do the language test first
 		let testResults = {};
-		let langMatch = fileBuffer.toString('utf8', 0, 1024).match(/lang\(([a-z\-]+?)\)/mi);
+		let langMatch = fileBuffer.toString('utf8', 0, 20971520).match(/lang\(([a-z\-]+?)\)/mi);
 		let langCode = (langMatch == null) ? false : langMatch[1];
 		testResults.language = langCode;
 


### PR DESCRIPTION
FIxes #12 (at least mostly).  The problem was the code only looked in the first 1kb for the language string.  In some cases the language string is set later in the file.  I increased the search to look in the first 20MB of the file.